### PR TITLE
Add branch specification to session1: filesystem task

### DIFF
--- a/content/en/docs/sessions/01-baby-steps/index.md
+++ b/content/en/docs/sessions/01-baby-steps/index.md
@@ -772,6 +772,13 @@ In this tutorial, we will see what we would need to do if we wanted to have a fi
 To make it easy, we will use the `9pfs` filesystem, as well as the `newlib` library.
 The latter is used so that we have available an API that would enable us to interact with this filesystem (functions such as `lseek`, `open`).
 
+**Note**: the build will fail if `unikraft` and `newlib` repositories aren't both on the `staging` or the `stable` branches.
+To avoid this situation, go to `~/.unikraft/unikraft` and checkout branch `staging`:
+```
+cd ~/.unikraft/unikraft
+git checkout staging
+```
+
 We will need to download `newlib`:
 ```
 git clone https://github.com/unikraft/lib-newlib.git ~/.unikraft/libs/newlib


### PR DESCRIPTION
Participants may try to use `~/.unikraft/unikraft` with head detached at
version 0.5 when solving the filesystem task. This will result in linking
errors due to incompatibilities with the staging version of newlib.
This commit adds a warning to avoid this situation.