### PR TITLE
Add current YouTube videos

### DIFF
--- a/content/en/docs/sessions/01-baby-steps/index.md
+++ b/content/en/docs/sessions/01-baby-steps/index.md
@@ -3,6 +3,8 @@ title: "Session 01: Baby Steps"
 linkTitle: "01. Baby Steps"
 ---
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/uLJeajTITGk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 In this session we are going to understand the basic layout of the Unikraft working directory, its environment variables, as well as what the most common Unikraft specific files mean.
 We are also going to take a look at how we can build basic applications and how we can extend their functionality and support by adding ported external libraries.
 

--- a/content/en/docs/sessions/02-behind-scenes/index.md
+++ b/content/en/docs/sessions/02-behind-scenes/index.md
@@ -3,6 +3,8 @@ title: "Session 02: Behind the Scenes"
 linkTitle: "02. Behind the Scenes"
 ---
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/JLN0fzR9S6g" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Reminders
 
 ### Kraft

--- a/content/en/docs/sessions/03-benchmarking-and-debugging/index.md
+++ b/content/en/docs/sessions/03-benchmarking-and-debugging/index.md
@@ -3,6 +3,8 @@ title: "Session 03: Benchmarking and Debugging"
 linkTitle: "03. Benchmarking and Debugging"
 ---
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/4VeA7_uJrXA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 Because unikernels aim to be a more efficient method of virtualization, this can sometimes cause problems.
 This session aims to familiarize you to solve any problem encountered during the development using **GDB** and **Tracepoints**.
 

--- a/content/en/docs/sessions/schedule.md
+++ b/content/en/docs/sessions/schedule.md
@@ -8,6 +8,8 @@ Unikraft Summer of Code 2021 (USoC'21) consists of 10 sessions in 10 days and a 
 Each session is 4 hours long and consists of practical demos and then exercises for participants.
 The hackathon is an 8 hours event where you'll have different tasks to enable, test, fix, evaluate and improve applications and libraries with Unikraft.
 
+All sessions are recorded and are available on [YouTube](https://www.youtube.com/playlist?list=PL0ZXUYDfkQ61pQ0Vkt4H5mjDoP267kSjA).
+
 The complete schedule for USoC'21 is (all times in CEST - Central European Summer Time):
 
 | Date | Interval | Activity | TA(s) |


### PR DESCRIPTION
This commit adds a reference to the youtube playlist of all videos of sessions and talks as well as places the youtube video (embeded) at the top of the first 3 sessions.